### PR TITLE
Add DEFROUTE.

### DIFF
--- a/src/core/caveman.lisp
+++ b/src/core/caveman.lisp
@@ -12,6 +12,7 @@
                 :redirect)
   (:import-from :caveman.route
                 :url
+                :defroute
                 :url-for)
   (:import-from :caveman.app
                 :next-route
@@ -32,6 +33,7 @@
            :*response*
            :*session*
            :context
+           :defroute
            :with-context-variables))
 
 (cl-syntax:use-syntax :annot)

--- a/src/core/route.lisp
+++ b/src/core/route.lisp
@@ -51,6 +51,18 @@ Example:
                 (url->routing-rule ,method ,url-rule ,form))
      ,form))
 
+
+
+(progn
+  @export
+  (defmacro defroute (method url-rule form)
+    "Recreation of @URL annotation in S-expression form"
+    `(progn
+       (add-route ,(intern "*APP*" *package*)
+                  (url->routing-rule ,method ,url-rule ,form))
+       ,form)))
+
+
 @doc "
 Convert action form into a routing rule, a list.
 
@@ -121,7 +133,7 @@ Example:
     (defun login (req)
       ;; response
       )
-    
+
     ;; for Clack Component
     @url GET \"/member/:id\"
     (defclass <member-profile> (<component>) ())


### PR DESCRIPTION
DEFROUTE provides a traditional Lisp S-expression mechanism for defining
routes(as opposed to @url). DEFROUTE is used exactly the same as @url,
and leverages identical underlying machinery. However, it will play nice
with emacs/SLIME considerably better.

It also looks more Lispy to some.
