### PR TITLE
Include `cl-test-more` Dependency for Quicklisp

### DIFF
--- a/caveman.asd
+++ b/caveman.asd
@@ -23,7 +23,8 @@
                :cl-fad
                :cl-emb
                :local-time
-               :cl-project)
+               :cl-project
+               :cl-test-more)
   :components ((:module "v1/src"
                 :components
                 ((:module "core"


### PR DESCRIPTION
When installing via Quicklisp, you receive the following when running the `(caveman.skeleton:generate)` command on a fresh install and building the first app skeleton:

```
* (caveman.skeleton:generate #p"~/test")
writing ~/test/.gitignore
writing ~/test/README.markdown
writing ~/test/README.org
writing ~/test/test-test.asd
writing ~/test/test.asd
writing ~/test/src/test.lisp
writing ~/test/t/test.lisp

debugger invoked on a MISSING-COMPONENT in thread
#<THREAD "main thread" RUNNING {1002978CB3}>:
  Component "cl-test-more" not found

Type HELP for debugger help, or (SB-EXT:QUIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [REINITIALIZE-SOURCE-REGISTRY-AND-RETRY] Retry finding system cl-test-more
                                              after reinitializing the
                                              source-registry.
  1: [RETRY                                 ] Retry EVAL of current toplevel form.
  2: [CONTINUE                              ] Ignore error and continue loading file "/home/al/test/test-test.asd".
  3: [ABORT                                 ] Abort loading file "/home/al/test/test-test.asd".
  4:                                          Exit debugger, returning to top
                                              level.

((LAMBDA () :IN FIND-SYSTEM))
0] 1
```

Therefore, cl-test-more is required to build a project skeleton that can be used by Caveman.
