### PR TITLE
Updates to documentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -376,7 +376,7 @@ There are several special variables available during a HTTP request. `*request*`
 (http-referer *request*)
 
 ;; Set Content-Type header.
-(setf (headers *response* :content-type) "application/json")
+(setf (getf (response-headers *response* :content-type) "application/json")
 
 ;; Set HTTP status.
 (setf (status *response*) 304)
@@ -386,7 +386,7 @@ If you would like to set Content-Type "application/json" for all "*.json" reques
 
 ```common-lisp
 (defroute "/*.json" ()
-  (setf (headers *response* :content-type) "application/json")
+  (setf (getf (response-headers *response*) :content-type) "application/json")
   (next-route))
 
 (defroute "/user.json" () ...)

--- a/README.markdown
+++ b/README.markdown
@@ -406,25 +406,31 @@ This example increments `:counter` in the session and displays it for each visit
           (incf (gethash :counter *session* 0))))
 ```
 
-Caveman2 stores the session data in-memory by default. To change it, specify `:store` to `<clack-middleware-session>` in "PROJECT_ROOT/app.lisp".
+Caveman2 stores the session data in-memory by default. To change it, specify `:store` to `:session` in "PROJECT_ROOT/app.lisp".
 
 This example uses RDBMS to store it.
 
 ```diff
-      (make-instance '<clack-middleware-backtrace>
-                     :output (getf (config) :error-log))
-      nil)
-- <clack-middleware-session>
-+ (<clack-middleware-session>
-+  :store (make-instance 'clack.session.store.dbi:<clack-session-store-dbi>
-+                        :connect-args (myapp.db:connection-settings)))
-+
++ (:import-from :lack.session.store.dbi
++               :make-dbi-store)
++ (:import-from :dbi
++               :connect)
++ (:import-from :appname.db
++               :connection-settings)
+...
+ (if (getf (config) :error-log)
+     '(:backtrace
+       :output (getf (config) :error-log))
+     nil)
+- :session
++  (:session
++   :store (make-dbi-store :connector (lambda () (apply #'connect (connection-settings))))
   (if (productionp)
       nil
       (lambda (app)
 ```
 
-NOTE: Don't forget to add `:clack-session-store-dbi` as `:depends-on` of your app. It is not a part of Clack.
+NOTE: Don't forget to add `:lack-session-store-dbi` as `:depends-on` of your app. It is not a part of Clack/Lack.
 
 See the documentation of Clack.Session.Store.DBi for more informations.
 


### PR DESCRIPTION
Hello,

I recently updated my application to work with the newest version of caveman 2 and noticed a few differences in the API that differs to what's currently documented.

I realize that Lack's API is in beta and prone to change so if this PR doesn't get accepted I understand. 

The changes mainly concern

1. Method to set and access header information (from headers to response-headers or request-headers)
2. Using a RDBMS to store session data using the lack builder DSL. 