### PR TITLE
Leave *dbi-manager* unbound by default

### DIFF
--- a/v2/src/middleware/dbimanager.lisp
+++ b/v2/src/middleware/dbimanager.lisp
@@ -10,9 +10,10 @@
            :connect-db))
 (in-package :caveman.middleware.dbimanager)
 
-(defvar *dbi-manager* nil
-  "An instance of `dbi-manager' for the current HTTP request.
-Since this variable meant to be bound lexically, this is available only during a HTTP request.")
+(defvar *dbi-manager*)
+(setf (documentation '*dbi-manager* 'variable)
+      "An instance of `dbi-manager' for the current HTTP request.
+This variable is only bound during the HTTP request.")
 
 (defclass dbi-manager ()
   ((database-settings :type list


### PR DESCRIPTION
If referred to outside the HTTP connection it should signal a variable unbound condition instead of returning nil.

Another option to leave it unbound would be to use the @documentation reader macro.