### PR TITLE
README: routes are to be defined in src/web.lisp

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -86,6 +86,7 @@ Caveman2 provides 2 ways to define a route -- `@route` and `defroute`. You can c
 `@route` is an annotation macro defined by using [cl-annot](https://github.com/arielnetworks/cl-annot). It takes a method, an URL-string and a function.
 
 ```common-lisp
+;; in src/web.lisp
 @route GET "/"
 (defun index ()
   ...)


### PR DESCRIPTION
Just a note to say that in the tutorial.

It would have saved me quite some time. Routes didn't work in views.lisp with a message I didn't understand and I finally found it in the quickdocs-server example. I'm new to CL and willing to get through starting-up difficulties.

Thanks !