### PR TITLE
Change defroute to allow autogeneration of documentation

### DIFF
--- a/v2/src/route.lisp
+++ b/v2/src/route.lisp
@@ -88,7 +88,7 @@
                                             (parse-parameters ,params))
                                            ,(params-form params lambda-list))
                                   (params-form params lambda-list))
-                              ,@(if declarations (list declarations) nil)
+                              ,@declarations
                               ,@body))
                          body)))
             (setf (apply #'ningle:route

--- a/v2/src/route.lisp
+++ b/v2/src/route.lisp
@@ -79,7 +79,7 @@
                    (alexandria:parse-body body :documentation t)
                  `(defun ,name (,params)
                     (declare (ignorable ,params))
-                    ,(or documentation (format nil "Handler for ~a" routing-rule))
+                    ,@(if documentation (list documentation))
                     ,@(if lambda-list
                           `((destructuring-bind ,(make-lambda-list lambda-list)
                                 ,(if (need-parsed-parameters lambda-list)


### PR DESCRIPTION
Documentation can be generated like this:
``` cl
(defroute doc "/doc" ()
  "This url shows this the documentation"
  (let ((docs (mapcar (lambda (route)
                        (list
                         (myway.rule::rule-url (myway.route:route-rule route))
                         (documentation (ningle.route:route-controller route) 'function)
                         (map-set:ms-map 'list 'identity (myway.rule::rule-methods (myway.route:route-rule route)))
                         (myway.rule::rule-param-keys (myway.route:route-rule route))))
                      (myway:mapper-routes (ningle.app::mapper *web*)))))
    (with-html-output-to-string (s nil :prologue t)
      (:html
       (:head)
       (:body
        (loop for (url docstring methods params) in docs
           do (htm (:h3 (str url) " " (fmt "~a" methods))
                   (if params (htm (:h4 (fmt " Params: ~a" params))))
                   (:div (str docstring)))))))))
```