### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -159,13 +159,13 @@ Route patterns may also contain "wildcard" parameters. They are accessible by `s
 ```common-lisp
 (defroute "/say/*/to/*" (&key splat)
   ; matches /say/hello/to/world
-  splat ;=> ("hello" "world")
-  ))
+  (format nil "~A" splat))
+;=> (hello world)
 
 (defroute "/download/*.*" (&key splat)
   ; matches /download/path/to/file.xml
-  splat ;=> ("path/to/file" "xml")
-  ))
+  (format nil "~A" splat)) 
+;=> (path/to/file xml)
 ```
 
 If you'd like to write a regular expression for URL rule, `:regexp t` should work for it.


### PR DESCRIPTION
I changed the "wildcard" parameters' examples as in keyword parameter and regex ones.  It could avoid misunderstanding for beginners like me.