### PR TITLE
Recovered missing render function for 404

### DIFF
--- a/v2/skeleton/src/web.lisp
+++ b/v2/skeleton/src/web.lisp
@@ -31,5 +31,5 @@
 
 (defmethod on-exception ((app <web>) (code (eql 404)))
   (declare (ignore app))
-  (merge-pathnames #P"_errors/404.html"
-                   *template-directory*))
+  (render (merge-pathnames #P"_errors/404.html"
+                           *template-directory*)))


### PR DESCRIPTION
`The value #P".../templates/_errors/404.html" is not of type SEQUENCE` occurs when routing is not found.

`on-exception` shall return rendered body.