### PR TITLE
missing paren

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -384,7 +384,7 @@ There are several special variables available during a HTTP request. `*request*`
 (http-referer *request*)
 
 ;; Set Content-Type header.
-(setf (getf (response-headers *response* :content-type) "application/json")
+(setf (getf (response-headers *response*) :content-type) "application/json")
 
 ;; Set HTTP status.
 (setf (status *response*) 304)


### PR DESCRIPTION
Just a simple missing a parenthesis in the markdown documentation. Was writing some code and can confirm that the change matches the behavior from the library.