### PR TITLE
README: app needs to be loaded before starting the server and moved the section towards the top

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -79,6 +79,37 @@ Caveman2 is now available on [Quicklisp](https://www.quicklisp.org/beta/).
 ;   writing /path/to/myapp/templates/layout/default.tmpl
 ```
 
+### Start a server
+This is a example that assumes that the name of your application is "myapp".
+Before starting the server, you must first load your app.
+
+```common-lisp
+(ql:quickload :myapp)
+```
+
+Your application has functions named `start` and `stop` to start/stop your web application. 
+
+```common-lisp
+(myapp:start :port 8080)
+```
+
+As Caveman is based on Clack/Lack, you can choose which server to run on -- Hunchentoot, mod_lisp or FastCGI.
+
+```common-lisp
+(myapp:start :server :hunchentoot :port 8080)
+(myapp:start :server :fcgi :port 8080)
+```
+
+I recommend you use Hunchentoot on a local machine, and use FastCGI/Woo in a production environment.
+
+You can also start your application by using [clackup command](https://github.com/fukamachi/clack/blob/master/roswell/clackup.ros).
+
+    $ ros install clack
+    $ which clackup
+    /Users/nitro_idiot/.roswell/bin/clackup
+
+    $ APP_ENV=development clackup --server :fcgi --port 8080 app.lisp
+
 ### Routing
 
 Caveman2 provides 2 ways to define a route -- `@route` and `defroute`. You can use either.
@@ -459,36 +490,6 @@ To specify error pages for 404, 500 or such, define a method `on-exception` of y
                    *template-directory*))
 ```
 
-### Start a server
-This is a example that assumes that the name of your application is "myapp".
-Before starting the server, you must first load your app.
-
-```common-lisp
-(ql:quickload :myapp)
-```
-
-Your application has functions named `start` and `stop` to start/stop your web application. 
-
-```common-lisp
-(myapp:start :port 8080)
-```
-
-As Caveman is based on Clack/Lack, you can choose which server to run on -- Hunchentoot, mod_lisp or FastCGI.
-
-```common-lisp
-(myapp:start :server :hunchentoot :port 8080)
-(myapp:start :server :fcgi :port 8080)
-```
-
-I recommend you use Hunchentoot on a local machine, and use FastCGI/Woo in a production environment.
-
-You can also start your application by using [clackup command](https://github.com/fukamachi/clack/blob/master/roswell/clackup.ros).
-
-    $ ros install clack
-    $ which clackup
-    /Users/nitro_idiot/.roswell/bin/clackup
-
-    $ APP_ENV=development clackup --server :fcgi --port 8080 app.lisp
 
 ### Hot Deployment
 

--- a/README.markdown
+++ b/README.markdown
@@ -460,8 +460,14 @@ To specify error pages for 404, 500 or such, define a method `on-exception` of y
 ```
 
 ### Start a server
+This is a example that assumes that the name of your application is "myapp".
+Before starting the server, you must first load your app.
 
-Your application has functions named `start` and `stop` to start/stop your web application. This is a example that assumes that the name of your application is "myapp".
+```common-lisp
+(ql:quickload :myapp)
+```
+
+Your application has functions named `start` and `stop` to start/stop your web application. 
 
 ```common-lisp
 (myapp:start :port 8080)

--- a/README.markdown
+++ b/README.markdown
@@ -80,7 +80,7 @@ Caveman2 is now available on [Quicklisp](https://www.quicklisp.org/beta/).
 ```
 
 ### Start a server
-This is a example that assumes that the name of your application is "myapp".
+This is an example that assumes that the name of your application is "myapp".
 Before starting the server, you must first load your app.
 
 ```common-lisp
@@ -93,14 +93,14 @@ Your application has functions named `start` and `stop` to start/stop your web a
 (myapp:start :port 8080)
 ```
 
-As Caveman is based on Clack/Lack, you can choose which server to run on -- Hunchentoot, mod_lisp or FastCGI.
+As Caveman is based on Clack/Lack, you can choose which server to run on -- Hunchentoot, Woo or Wookie, etc.
 
 ```common-lisp
 (myapp:start :server :hunchentoot :port 8080)
 (myapp:start :server :fcgi :port 8080)
 ```
 
-I recommend you use Hunchentoot on a local machine, and use FastCGI/Woo in a production environment.
+I recommend you use Hunchentoot on a local machine, and use Woo in a production environment.
 
 You can also start your application by using [clackup command](https://github.com/fukamachi/clack/blob/master/roswell/clackup.ros).
 


### PR DESCRIPTION
I had a slight hitch in starting the server, and also finding the information about how to start the server. I've added a step in the start a server section and also I have moved that section to the top right after installation, I think this ordering makes more sense.

P.S this is my first OS contribution so I'm sorry If made mistakes or the commit messages are unclear.